### PR TITLE
Bugfix on missing routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ server.route({
 	method: 'GET',
 	path: '/{format?}',
 	handler: function(request, reply){
-		var shaltFallback = !request.params.format && !sticazzi[request.params.format],
+		var shaltFallback = !(request.params.format && sticazzi[request.params.format]),
 			obj = shaltFallback ? sticazzi.root : sticazzi[request.params.format],
 			r = {response: obj.value};
 

--- a/app.js
+++ b/app.js
@@ -19,7 +19,9 @@ server.route({
 			r = {response: obj.value};
 
 		Utils.requestFormatter(request, r).dilate(request, r, obj.big);
-		return reply(JSON.stringify(r)).type('application/json');
+
+		var statusCode = (shaltFallback && request.params.format) ? 404 : 200;
+		return reply(JSON.stringify(r)).type('application/json').code(statusCode);
 	},
 	config: {
 		cache: {


### PR DESCRIPTION
On missing routes the server was exploding with a 500 error.
Now it's returning a 404 with the default response.